### PR TITLE
Prepare for upcoming change to HttpRequest and HttpClientResponse

### DIFF
--- a/test/embed_shelf_test.dart
+++ b/test/embed_shelf_test.dart
@@ -79,7 +79,7 @@ main() {
       var client = new HttpClient();
       var rq = await client.openUrl('GET', Uri.parse('$url/hijack'));
       var rs = await rq.close();
-      var body = await rs.transform(utf8.decoder).join();
+      var body = await rs.cast<List<int>>().transform(utf8.decoder).join();
       print('Response: $body');
       expect(json.decode(body), {'error': 'crime'});
     } on HttpException catch (e, st) {


### PR DESCRIPTION
An upcoming change to the Dart SDK will change `HttpRequest` and
`HttpClientResponse` from implementing `Stream<List<int>>` to
implementing `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900